### PR TITLE
add explanation field to settings

### DIFF
--- a/app/controllers/admin/settings/edit.js
+++ b/app/controllers/admin/settings/edit.js
@@ -7,7 +7,7 @@ export default Controller.extend(saveModelMixin, {
   settings: service(),
   init() {
     this._super(...arguments);
-    this.requiredProperties = ["title"];
+    this.requiredProperties = ["title", "explanation"];
     this.types = ["boolean", "string", "number", "date"]
   },
   noticeDuringSave: "Updating setting...",

--- a/app/models/setting.js
+++ b/app/models/setting.js
@@ -5,14 +5,14 @@ const { attr, Model } = DS;
 
 export default Model.extend({
   title: attr('string'),
-  
+  explanation: attr('string'),
+
   stringValue: attr('string'),
   booleanValue: attr('boolean'),
   numberValue: attr('number'),
   dateValue: attr('date'),
 
   order: attr('number'),
-
   type: attr('string'),
 
   value: computed('type', 'stringValue', 'booleanValue', 'numberValue', 'dateValue', function() {

--- a/app/templates/admin/settings/form.hbs
+++ b/app/templates/admin/settings/form.hbs
@@ -19,10 +19,18 @@
                 <span class="text"> Title * </span>
                 {{input type="text" class="form-control mb-2" placeholder="e.g. LinkedInLink" value=model.title}} 
               </label>
+              <label>
+                <span class="text"> Explanation * </span>
+                {{input type="text" class="form-control mb-2" placeholder="e.g. description at join page" value=model.explanation}} 
+              </label>
             {{else }}
               <label>
                 <span class="text"> Title * </span>
                 {{input type="text" class="form-control mb-2" disabled=true placeholder="e.g. LinkedInLink" value=model.title}} 
+              </label>
+              <label>
+                <span class="text"> Explanation * </span>
+                {{input type="text" class="form-control mb-2" disabled=true placeholder="e.g. description at join page" value=model.explanation}} 
               </label>
             {{/if}}
           </div>

--- a/app/templates/admin/settings/index.hbs
+++ b/app/templates/admin/settings/index.hbs
@@ -28,6 +28,7 @@
             <th> # </th>
           {{/if}}
           <th scope="col" class="border-0"> Title </th>
+          <th scope="col" class="border-0"> Explanation </th>
           <th scope="col" class="border-0"> Type </th>
           <th scope="col" class="border-0"> Value </th>
           <th scope="col" class="border-0"> Options </th>
@@ -41,6 +42,7 @@
               <td> <span class="handle"><small><i class="fa fa-bars text-small" aria-hidden="true"></i> </small></span> </td>
             {{/if}}
             <td> {{setting.title}} </td>
+            <td> {{setting.explanation}} </td>
             <td>{{setting.type}}</td>
             <td>{{setting.valueShortened}}</td>
             <td> 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-source": "~3.4.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-welcome-page": "^3.2.0",
-    "emberfire": "github:firebase/emberfire#master",
+    "emberfire": "^2.0.10",
     "emberx-file-input": "^1.2.1",
     "eslint-plugin-ember": "^5.2.0",
     "liquid-fire": "^0.29.5",


### PR DESCRIPTION
adds explanation field to settings. settings should have a clear description about what they do to significantlyimprove usability of the backend