### PR TITLE
Fix for date on event page

### DIFF
--- a/app/templates/events/show.hbs
+++ b/app/templates/events/show.hbs
@@ -5,7 +5,11 @@
         {{#link-to "events"}} &laquo; Events {{/link-to}}
         <span> 
           <h1> {{model.title}} </h1>
-          <h4 class="mb-0 text-muted"> ({{moment-format event.startDate "MMM/DD"}} - {{moment-format event.endDate "MMM/DD"}}) </h4> 
+          {{#if (is-same model.startdate model.enddate precision='days')}}
+            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MM/DD"}} </h4>
+          {{else}}
+            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MM/DD"}} - {{moment-format model.enddate "MM/DD"}} </h4>
+          {{/if}}
         </span>
       </div>
       {{#if model.link}}

--- a/app/templates/events/show.hbs
+++ b/app/templates/events/show.hbs
@@ -6,9 +6,9 @@
         <span> 
           <h1> {{model.title}} </h1>
           {{#if (is-same model.startdate model.enddate precision='days')}}
-            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MM/DD"}} </h4>
+            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MMM/DD"}} </h4>
           {{else}}
-            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MM/DD"}} - {{moment-format model.enddate "MM/DD"}} </h4>
+            <h4 class="mb-0 text-muted"> {{moment-format model.startdate "MMM/DD"}} - {{moment-format model.enddate "MMM/DD"}} </h4>
           {{/if}}
         </span>
       </div>


### PR DESCRIPTION
The event page now shows the start and end date of the event instead of the date of today.